### PR TITLE
ci: install helm-docs and helm-schema in the renovate container

### DIFF
--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -7,4 +7,21 @@ apt install -y nodejs
 node -v
 npm -v
 
+# helm-docs + helm-schema so chart repos can regenerate the committed README.md
+# and values.schema.json from a Renovate postUpgrade task (mise run helm-docs /
+# generate). Without this, a values.yaml bump in a Renovate PR leaves the chart
+# docs stale and the Helm Lint (helm-docs-check) job fails.
+# renovate: datasource=github-releases depName=norwoodj/helm-docs
+HELM_DOCS_VERSION=1.14.2
+# renovate: datasource=github-releases depName=dadav/helm-schema
+HELM_SCHEMA_VERSION=0.23.4
+
+curl -fsSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION#v}/helm-docs_${HELM_DOCS_VERSION#v}_Linux_x86_64.tar.gz" \
+  | tar -xz -C /usr/local/bin helm-docs
+curl -fsSL "https://github.com/dadav/helm-schema/releases/download/${HELM_SCHEMA_VERSION#v}/helm-schema_${HELM_SCHEMA_VERSION#v}_Linux_x86_64.tar.gz" \
+  | tar -xz -C /usr/local/bin helm-schema
+
+helm-docs --version
+helm-schema --version
+
 runuser -u ubuntu renovate


### PR DESCRIPTION
Installs the `helm-docs` and `helm-schema` binaries in the Renovate container's entrypoint (the same way `nodejs` is installed today), so chart repos can regenerate their committed `README.md` and `values.schema.json` from a Renovate **postUpgrade task**.

## Why

The chart repos (konflate, kromgo, tuppr, kopiur) ship a helm-docs-generated `README.md` + `values.schema.json` and gate them in CI with `helm-docs-check` (the **Helm Lint** job). When Renovate bumps a value that the chart renders — e.g. an image tag in `values.yaml` — the committed docs go stale and that job fails, with no way for the bot to self-heal. Example: [home-operations/konflate#63](https://github.com/home-operations/konflate/pull/63) (a `busybox` bump) failed **Helm Lint** for exactly this reason.

With the tools in the container, a postUpgrade task can run `mise run helm-docs` (or `mise run generate` in konflate) and commit the regenerated docs in the same PR.

## Notes

- Versions are pinned (`helm-docs` 1.14.2, `helm-schema` 0.23.4) to match the chart repos' `.mise` pins, with `# renovate:` annotations. Heads-up: this repo extends `renovate-config`, which doesn't currently include the annotated-version custom manager (that lives in `renovate-presets`), so those pins won't auto-bump until the manager is added to the chain — same situation as the existing unmanaged `nodejs` line.
- **This is only half the fix** — the postUpgrade task itself still needs to be wired into the shared Renovate config so PRs like konflate#63 actually self-heal. Happy to follow up with that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
