### PR TITLE
ci: allowlist helm-docs/helm-schema for renovate postUpgrade tasks

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -67,6 +67,9 @@ jobs:
           RENOVATE_PLATFORM_COMMIT: true
           RENOVATE_CUSTOM_ENV_VARIABLES: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/renovate/repos"}'
           RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["goGenerate", "mise"]'
+          # Allowlist the chart-doc regeneration commands used by per-repo
+          # postUpgradeTasks (helm-docs + helm-schema ship in the entrypoint above).
+          RENOVATE_ALLOWED_COMMANDS: '["^helm-docs ", "^helm-schema "]'
         with:
           docker-cmd-file: .github/renovate-entrypoint.sh
           docker-user: root


### PR DESCRIPTION
Follow-up to #14 (which installed `helm-docs` + `helm-schema` in the Renovate container). This sets `allowedCommands` so the chart repos' postUpgrade tasks are actually permitted to run those binaries.

## Why this is required

Custom `postUpgradeTasks` commands are gated by Renovate's **`allowedCommands`** regex allowlist — and **if it's empty, the tasks are skipped entirely**. The existing `allowedUnsafeExecutions: ["goGenerate", "mise"]` only covers Renovate's *built-in* mise/goGenerate handling, not user-defined postUpgrade commands.

With `allowedCommands` permitting `^helm-docs ` and `^helm-schema `, a per-repo postUpgrade task can regenerate a chart's `README.md` + `values.schema.json` after a dependency bump and commit them in the same PR — fixing the stale-docs Helm Lint failure seen in e.g. [home-operations/konflate#63](https://github.com/home-operations/konflate/pull/63). The commands invoke the binaries directly (installed in the entrypoint by #14) rather than via `mise run`, so they don't re-install tooling on every run.

The per-repo `postUpgradeTasks` blocks land separately in each chart repo's `.renovaterc.json5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
