### PR TITLE
ci: add an annotated-dependencies regex manager

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,4 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["local>home-operations/renovate-config"],
+  extends: [
+    "local>home-operations/renovate-config",
+    "local>home-operations/.github//annotated.json5",
+  ],
 }

--- a/annotated.json5
+++ b/annotated.json5
@@ -1,0 +1,26 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Process annotated dependencies",
+      managerFilePatterns: ["/\\.env(?:\\.j2)?$/", "/\\.sh(?:\\.j2)?$/", "/\\.yaml(?:\\.j2)?$/"],
+      matchStrings: [
+        // # renovate: datasource=github-releases depName=foo/bar
+        // foobar_version: v1.0.0
+        // # renovate: datasource=github-releases depName=foo/bar
+        // foobar_version: "v1.0.0"
+        // # renovate: datasource=github-releases depName=foo/bar
+        // foobar_version: &version v1.0.0
+        // # renovate: datasource=github-releases depName=foo/bar
+        // foobar_version: &version "v1.0.0"
+        // # renovate: datasource=docker depName=ghcr.io/foo/bar
+        // FOOBAR_VERSION=v1.0.0
+        // # renovate: datasource=docker depName=ghcr.io/foo/bar
+        // FOOBAR_VERSION="v1.0.0"
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+(:\\s|=)(&\\S+\\s)?[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
+      ],
+      datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+    },
+  ],
+}


### PR DESCRIPTION
Adds an `annotated.json5` customManager that processes `# renovate:` annotation comments in `.env` / `.sh` / `.yaml` files (the org's existing rule, previously only in `renovate-presets`), and extends it from this repo's config.

## Effect

With this, Renovate processes the annotated tool-version pins this repo already carries — the `helm-docs` / `helm-schema` versions in `.github/renovate-entrypoint.sh` (added in #14) now get bumped like any other dependency instead of sitting as static magic numbers.

The preset is reusable: any repo can pick it up with

```json5
extends: ["local>home-operations/.github//annotated.json5"]
```

which is how the chart repos will make their own annotated versions (e.g. the `helm-unittest` plugin pin) renovatable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
