### PR TITLE
feat(renovate): persist the repository cache and reuse resolved presets

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -28,9 +28,9 @@ on:
         type: choice
         default: enabled
         options:
-          - enabled # restore + reuse the cache (the scheduled default)
-          - disabled # ignore the cache entirely
-          - reset # rebuild the cache from scratch this run
+          - enabled
+          - disabled
+          - reset
 
 permissions:
   contents: read
@@ -54,7 +54,7 @@ jobs:
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }} # org-wide access is required for Renovate autodiscover
+          owner: ${{ github.repository_owner }}
           permission-checks: write
           permission-contents: write
           permission-issues: write
@@ -64,11 +64,6 @@ jobs:
           permission-vulnerability-alerts: read
           permission-workflows: write
 
-      # Restore the per-repo extraction cache (deps + branch/PR state) so an
-      # unchanged repo is skipped instead of re-scanned. The runner is ephemeral,
-      # so it round-trips through actions/cache. A run-scoped key with a shared
-      # restore-keys prefix means each run restores the latest cache and saves a
-      # fresh one — no immutable-key clash and no cache deletion needed.
       - name: Restore Renovate repository cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -96,23 +91,13 @@ jobs:
           RENOVATE_CUSTOM_ENV_VARIABLES: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/renovate/repos"}'
           RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["goGenerate", "mise"]'
           RENOVATE_ALLOWED_COMMANDS: '["^helm-docs ", "^helm-schema ", "^cargo update "]'
-          # Persist per-repo extraction across runs (restored/saved via the cache
-          # steps) so an unchanged repo is skipped, not re-scanned. A manual run
-          # can override this — e.g. "reset" to rebuild a stale cache.
           RENOVATE_REPOSITORY_CACHE: ${{ inputs.repoCache || 'enabled' }}
-          # Resolve the shared renovate-config preset once and reuse it for every
-          # repo in the run instead of re-fetching it per repo.
           RENOVATE_PRESET_CACHE_PERSISTENCE: "true"
         with:
           docker-cmd-file: .github/renovate-entrypoint.sh
           docker-user: root
           token: ${{ steps.app-token.outputs.token }}
-          # Pin the Renovate version for reproducible runs and a stable cache schema.
-          # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
-          renovate-version: 43.244.4
 
-      # Save the (container-owned, world-readable) repository cache for the next
-      # run. Always run so a failed run still persists the progress it made.
       - name: Save Renovate repository cache
         if: always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -23,6 +23,14 @@ on:
         options:
           - debug
           - info
+      repoCache:
+        description: Repository cache
+        type: choice
+        default: enabled
+        options:
+          - enabled # restore + reuse the cache (the scheduled default)
+          - disabled # ignore the cache entirely
+          - reset # rebuild the cache from scratch this run
 
 permissions:
   contents: read
@@ -32,6 +40,7 @@ jobs:
     name: Renovate
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: read
     steps:
       - name: Checkout
@@ -45,7 +54,7 @@ jobs:
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }} # zizmor: ignore[github-app] org-wide access is required for Renovate autodiscover
+          owner: ${{ github.repository_owner }} # org-wide access is required for Renovate autodiscover
           permission-checks: write
           permission-contents: write
           permission-issues: write
@@ -54,6 +63,25 @@ jobs:
           permission-statuses: write
           permission-vulnerability-alerts: read
           permission-workflows: write
+
+      # Restore the per-repo extraction cache (deps + branch/PR state) so an
+      # unchanged repo is skipped instead of re-scanned. The runner is ephemeral,
+      # so it round-trips through actions/cache. A run-scoped key with a shared
+      # restore-keys prefix means each run restores the latest cache and saves a
+      # fresh one — no immutable-key clash and no cache deletion needed.
+      - name: Restore Renovate repository cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/renovate/cache/renovate/repository
+          key: renovate-repository-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: renovate-repository-cache-
+
+      - name: Align cache ownership for the Renovate container
+        run: |
+          sudo mkdir -p /tmp/renovate/cache/renovate/repository
+          # Renovate runs in its container as uid 12021; give it ownership so it
+          # can read and rewrite the restored cache.
+          sudo chown -R 12021:0 /tmp/renovate
 
       - name: Renovate
         uses: renovatebot/github-action@6d859fc95779be83a0335ca704879b47e5d79641 # v46.1.16
@@ -68,7 +96,26 @@ jobs:
           RENOVATE_CUSTOM_ENV_VARIABLES: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/renovate/repos"}'
           RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["goGenerate", "mise"]'
           RENOVATE_ALLOWED_COMMANDS: '["^helm-docs ", "^helm-schema ", "^cargo update "]'
+          # Persist per-repo extraction across runs (restored/saved via the cache
+          # steps) so an unchanged repo is skipped, not re-scanned. A manual run
+          # can override this — e.g. "reset" to rebuild a stale cache.
+          RENOVATE_REPOSITORY_CACHE: ${{ inputs.repoCache || 'enabled' }}
+          # Resolve the shared renovate-config preset once and reuse it for every
+          # repo in the run instead of re-fetching it per repo.
+          RENOVATE_PRESET_CACHE_PERSISTENCE: "true"
         with:
           docker-cmd-file: .github/renovate-entrypoint.sh
           docker-user: root
           token: ${{ steps.app-token.outputs.token }}
+          # Pin the Renovate version for reproducible runs and a stable cache schema.
+          # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
+          renovate-version: 43.244.4
+
+      # Save the (container-owned, world-readable) repository cache for the next
+      # run. Always run so a failed run still persists the progress it made.
+      - name: Save Renovate repository cache
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /tmp/renovate/cache/renovate/repository
+          key: renovate-repository-cache-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/safe-settings.yaml
+++ b/.github/workflows/safe-settings.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }} # zizmor: ignore[github-app] org-wide listing
+          owner: ${{ github.repository_owner }} # org-wide listing
           permission-metadata: read
 
       # safe-settings PATCHes every installation repo it sees, including

--- a/.github/workflows/safe-settings.yaml
+++ b/.github/workflows/safe-settings.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }} # org-wide listing
+          owner: ${{ github.repository_owner }}
           permission-metadata: read
 
       # safe-settings PATCHes every installation repo it sees, including

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,9 +1,4 @@
 ---
-# The Renovate and safe-settings bots use an org-wide GitHub App installation
-# token: both must operate across every repository in the org (Renovate
-# autodiscovers and opens PRs across all repos; safe-settings lists all repos to
-# apply org policy), so scoping the token to a fixed repository list would defeat
-# their purpose. The per-permission scopes on each token are still kept minimal.
 rules:
   github-app:
     ignore:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+---
+# The Renovate and safe-settings bots use an org-wide GitHub App installation
+# token: both must operate across every repository in the org (Renovate
+# autodiscovers and opens PRs across all repos; safe-settings lists all repos to
+# apply org policy), so scoping the token to a fixed repository list would defeat
+# their purpose. The per-permission scopes on each token are still kept minimal.
+rules:
+  github-app:
+    ignore:
+      - renovate.yaml
+      - safe-settings.yaml

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -48,6 +48,7 @@ checksum = "sha256:6b4484c2190274175df9aa8f28e2d758a819cb1c1fe6ab481e2f95b463ab8
 url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:b1c6c2dc31b46dd8fb2322f4fe75b07e775c5120bc37251deeea28f529d4567b"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
@@ -55,6 +56,7 @@ checksum = "sha256:783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050
 url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:ea58409911e141ec6b19d9178efa2d9185a13295005b1cbf5521b3157eed1d95"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]


### PR DESCRIPTION
## Why

Renovate runs hourly across the whole org via autodiscover on an ephemeral `ubuntu-latest` runner. Every run starts **cold**: it re-extracts every repo and re-resolves the shared `renovate-config` preset from scratch, so wall-clock grows with each repo we add. These settings make unchanged work cheap without changing the central-autodiscover model.

## What

- **`RENOVATE_REPOSITORY_CACHE`** + **`actions/cache`** (restore before / save after) — Renovate's per-repo extraction cache survives across the ephemeral runs, so a repo with no base-branch change is skipped instead of re-scanned.
- **`RENOVATE_PRESET_CACHE_PERSISTENCE: true`** — the shared preset is resolved once per run and reused for every repo.
- **`repoCache` `workflow_dispatch` input** (`enabled` / `disabled` / `reset`) — a manual run can bypass the cache or rebuild a stale one; scheduled runs default to `enabled`.
- **Pinned `renovate-version`** for reproducible runs and a stable cache schema, kept current by the org's annotated custom manager.
- **Central `.github/zizmor.yml`** — the inline `zizmor: ignore[github-app]` suppressions in `renovate.yaml` and `safe-settings.yaml` (both legitimately need an org-wide App token for autodiscover / org-wide listing) are moved into a config file.

## Notes for review

- **First-party `actions/cache`** (`v6.1.0`, SHA-pinned), per renovatebot/github-action#827 and the [polyworld example](https://github.com/kyhule/polyworld-renovate/blob/main/.github/workflows/renovate.yml) — no third-party action.
- **Keying:** run-scoped key (`renovate-repository-cache-<run_id>-<run_attempt>`) + shared `restore-keys:` prefix. Each run restores the most recent cache and saves a fresh entry, so there's no immutable-key clash and **no cache-deletion step** — hence **no extra `actions:` permission** (cache uses the Actions runtime token). GitHub evicts stale entries automatically.
- **uid handling:** the restored tree is `chown`ed to the container's **uid 12021** so Renovate can rewrite it; save reads the files back as the runner (Renovate writes them world-readable, so no chown-back is needed).
- **Failure mode is safe:** `save` runs on `always()`; if restore/save no-ops or errors, Renovate just runs cold that cycle.
- **Deferred:** a shared **datasource** cache via Redis (`RENOVATE_REDIS_URL`) — the other half (version-lookup reuse) — left as a follow-up since it needs a reachable Redis.

zizmor (now reading `.github/zizmor.yml`) and yaml-format pass via lefthook.