### PR TITLE
ci(renovate): drop the now-unused cargo update allowed-command

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -90,7 +90,7 @@ jobs:
           RENOVATE_PLATFORM_COMMIT: true
           RENOVATE_CUSTOM_ENV_VARIABLES: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/renovate/repos"}'
           RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["goGenerate", "mise"]'
-          RENOVATE_ALLOWED_COMMANDS: '["^helm-docs ", "^helm-schema ", "^cargo update "]'
+          RENOVATE_ALLOWED_COMMANDS: '["^helm-docs ", "^helm-schema "]'
           RENOVATE_REPOSITORY_CACHE: ${{ inputs.repoCache || 'enabled' }}
           RENOVATE_PRESET_CACHE_PERSISTENCE: "true"
         with:


### PR DESCRIPTION
## What

Drop `^cargo update ` from `RENOVATE_ALLOWED_COMMANDS` (helm-docs / helm-schema stay).

```diff
-RENOVATE_ALLOWED_COMMANDS: '["^helm-docs ", "^helm-schema ", "^cargo update "]'
+RENOVATE_ALLOWED_COMMANDS: '["^helm-docs ", "^helm-schema "]'
```

## Why

This allowance existed only for a cargo `cargo update --package {{depName}}` `postUpgradeTask` that worked around `cargo update --workspace` refusing transitive bumps on cargo **git** dependencies. That approach is retired org-wide:

- **drm-exporter** moved its only git cargo dep (qmlib) to a crates.io registry dep — home-operations/drm-exporter#33
- **kopiur**'s cargo rule was dead config (no git cargo deps) and is removed — home-operations/kopiur#177
- the shared `renovate-config` / `renovate-presets` carry no cargo `postUpgradeTask`

With no repo invoking `cargo update`, the allowance is unused — Renovate's built-in cargo manager refreshes `Cargo.lock` natively. Dropping it keeps the org-wide allowed-command surface minimal; trivial to re-add if a genuine need arises.

Safe regardless of merge order: kopiur/drm-exporter's rules never matched (no git cargo deps), so `cargo update` was never actually executed even today.
