### PR TITLE
ci: pin .github workflows to ubuntu-24.04

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   renovate:
     name: Renovate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/safe-settings.yaml
+++ b/.github/workflows/safe-settings.yaml
@@ -29,7 +29,7 @@ env:
 jobs:
   full-sync:
     name: Reconcile org repository settings
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout safe-settings
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   stale:
     name: Stale
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
## What

Pin the three `.github` workflows still on `runs-on: ubuntu-latest` to `ubuntu-24.04`: `renovate.yaml`, `safe-settings.yaml`, `stale.yaml`.

## Why

`ubuntu-24.04` is the de-facto org standard — **186 of ~195** workflow jobs already use it, and **every repo's own `stale.yaml` is already `24.04`**. Only the `.github` org-meta workflows lagged on the floating `ubuntu-latest` alias. Pinning them removes the last of the runner drift and stops GitHub silently moving the runner under the org's automation. (`.private/safe-settings-sync.yaml` is already `24.04`; nothing else in the repo uses `ubuntu-latest`.)

Part of the org consolidation audit — Tier 1.
