### PR TITLE
feat: shared goreleaser partials for CLI releases (Pro includes)

### DIFF
--- a/goreleaser.common.yaml
+++ b/goreleaser.common.yaml
@@ -1,0 +1,43 @@
+---
+version: 2
+# Shared goreleaser partial for every home-operations CLI release, pulled in
+# via goreleaser Pro's `includes.from_url` (like lefthook.common.toml is for
+# hooks). Language-agnostic blocks only — Go-specific ones live in
+# goreleaser.go-cli.yaml.
+#
+# Rule for composing with a repo's local config: each top-level key must be
+# defined in exactly ONE file (here or locally, never both) — goreleaser does
+# not document list/map merge semantics across includes, so overlap is
+# undefined behavior.
+#
+# Consumers: flate, yayamlls (kopiur can adopt once its release PR lands).
+# Changes here apply to every consumer's NEXT release — treat edits like a
+# shared-workflow change.
+
+# Split per-artifact .sha256 files (not one big checksums.txt).
+checksum:
+  algorithm: sha256
+  split: true
+
+sboms:
+  - artifacts: archive
+    documents:
+      - "{{ .ArtifactName }}.sbom.json"
+
+# Keyless Cosign bundle per artifact, verifiable with
+# `cosign verify-blob --bundle <artifact>.sigstore.json <artifact>`.
+signs:
+  - cmd: cosign
+    signature: ${artifact}.sigstore.json
+    args:
+      - sign-blob
+      - --bundle=${signature}
+      - --yes
+      - ${artifact}
+    artifacts: all
+    output: true
+
+# release-please creates the GitHub Release with the changelog; goreleaser
+# only attaches binaries/sboms/sigs to it.
+release:
+  mode: keep-existing

--- a/goreleaser.go-cli.yaml
+++ b/goreleaser.go-cli.yaml
@@ -1,0 +1,23 @@
+---
+version: 2
+# Shared goreleaser partial for the org's Go CLIs (flate, yayamlls) — include
+# AFTER goreleaser.common.yaml. Go-specific blocks only; see the composition
+# rule in goreleaser.common.yaml (each top-level key lives in exactly one
+# file). The per-repo config keeps `builds` and `homebrew_casks` — names,
+# paths, and metadata differ per project.
+
+before:
+  hooks:
+    - go mod tidy
+
+# Applies to all builds (no `ids` filter — each repo defines exactly one).
+archives:
+  - format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+upx:
+  - enabled: true
+    compress: best
+    lzma: true


### PR DESCRIPTION
## What

Two shared goreleaser partials, consumed by the CLI repos via goreleaser **Pro**'s `includes.from_url` — the same shared-home pattern as `lefthook.common.toml`:

- **`goreleaser.common.yaml`** (language-agnostic): split per-artifact sha256, syft SBOMs, keyless cosign bundles, `release: keep-existing` (release-please owns changelogs).
- **`goreleaser.go-cli.yaml`** (Go CLIs): `go mod tidy` before-hook, windows-zip archive override, upx.

Both files state the composition rule: each top-level key lives in exactly one file (shared or local, never both) — goreleaser doesn't document cross-include list-merge semantics, so overlap is undefined behavior.

## Consumers

flate and yayamlls convert in companion PRs (their local configs shrink to `builds` + `homebrew_casks`); kopiur can adopt `goreleaser.common.yaml` after home-operations/kopiur#187 lands. Changes to these files apply to every consumer's **next release** — treat edits like a shared-workflow change.

Verified with the goreleaser-pro binary that includes resolve during `goreleaser check` without a license key (the key gates publishing only), so consumer PR checks stay keyless; release-time publishing needs the org-level `GORELEASER_KEY` secret (pending).

**Merge order**: this PR first — the consumer configs 404 on the raw URL until these files exist on main.